### PR TITLE
dns: replace wwwizer with cloudflare redirect

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.7.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:1af0SiRude2KSo4HeAhdKdL89kftor+1ZhtxbBEV1DI=",
+    "zh:0bbd2eaa8210b2214dc426a2471b38cee53db9750b4916b34b0926fc9cbe4d7b",
+    "zh:0de3675e2ace7478ab0d354b2b6db4be2ae5a9a5e68b725cdd10e956131ec687",
+    "zh:4787a255919911aac5e1f8d47ed19fa45e5b90439ecf1fffbb17ff8bfb28de79",
+    "zh:4eb1e4300b3cdee3a323457ebcc8df29a735ea6bbabe3cf9cbd3dc3fb5a9172b",
+    "zh:580bbd5a727c9e3f31ae47c872df860c9a08ea998e0ff3dfe37dbac536146166",
+    "zh:6a359212678ffcf88551e2d8d0f8e52418031cf1f8077bb8ddf500171ee90f2b",
+    "zh:bec6890cb11511577c5f8ec8954e26ac51c44a114cb3e0349fea40f87930c029",
+    "zh:dbe3585510283c8e53a2b24cc7a69fab0ee9d71addae0db1be0374bc32fc6355",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.5.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:g6DAfVQSalAfjQgMYoGDlj4N9kcFVY6xe7G9+mXQDMU=",
+    "zh:0257c2719dc8508bc3ef5ac8df3c84b3ef61211ec46b6e5ed951681bbfe08d22",
+    "zh:3828d4409e2a68fccc9f9fb583167501cc4d38a5ecbb2408cb5781096739311b",
+    "zh:3cf7062a4a2530c2137473cc4281fd088cfe0059ad8cdb766e2083ac02c85aa9",
+    "zh:44c2caadd5d3ad4a69a646251319cce406c9800b2b823c2c59e8b0a3ea73fabd",
+    "zh:4924d88dbb45c9a01dc69323f731b969c2562631832509525ad44331e3682f43",
+    "zh:5ff081d29aaeb160753f7ba412d218dfd8703f2aeb0bc6cebe5f91c94bf1376a",
+    "zh:6d3f2c29b3c51629cb9ea2b513a981fb98226c69eeda670bb4d2b5cd0af8d278",
+    "zh:7df20d6ce088b131501f5dae9c3de763f81ac266000c19d4d53be79f568ecd24",
+    "zh:93c1ecaeedbc76b28297480d6456c6e65d80c72a20f6e870e537d7d80531c911",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ae8197c75460e25a664e76c183de79b798a82f31dcd99b44c6af2fd3ef249f5f",
+    "zh:aeacc428aa1f99a55432c969fb636dc6fc3346c6a95ebdcc5a240c222fbf0504",
+    "zh:be6d310269605985a8cf1d4d7984f3199b183dfc8cb3674c286c5bcfd4de7eb4",
+    "zh:c3ecd7a38af22d32479bcbca3c74c53969d71665ad4203b3102cbf519d6ddee7",
+    "zh:de127f5130604540b2be99c6b8b8253f4694a0a827cc9d186d72b545f27c45a5",
+  ]
+}

--- a/dns.tf
+++ b/dns.tf
@@ -6,12 +6,25 @@ resource "cloudflare_zone" "vanity" {
   name = "bendrucker.me"
 }
 
-resource "cloudflare_dns_record" "wwwizer" {
+resource "cloudflare_dns_record" "apex" {
   zone_id = cloudflare_zone.vanity.id
   name    = cloudflare_zone.vanity.name
   type    = "A"
-  content = "174.129.25.170"
+  content = "192.0.2.1" # RFC 5737 TEST-NET-1 placeholder IP, actual traffic handled by Cloudflare proxy
   ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_page_rule" "apex_to_www" {
+  zone_id = cloudflare_zone.vanity.id
+  target  = "bendrucker.me/*"
+  
+  actions = {
+    forwarding_url = {
+      url         = "https://www.bendrucker.me/$1"
+      status_code = 301
+    }
+  }
 }
 
 resource "cloudflare_dns_record" "github" {
@@ -29,35 +42,6 @@ resource "cloudflare_dns_record" "txt" {
   type    = "TXT"
   content = "keybase-site-verification=8ic85gbwQMRpqKksDrw_hQdsvg9WEVvX2UBvEiPHhwk"
   ttl     = 1
-}
-
-removed {
-  from = cloudflare_record.wwwizer
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
-  from = cloudflare_record.github
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
-  from = cloudflare_record.txt
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-import {
-  to = cloudflare_dns_record.wwwizer
-  id = "c783f775892feb7781197c65222d9612/a132e35e44ae39deabc7905eb9778248"
 }
 
 import {

--- a/dns.tf
+++ b/dns.tf
@@ -18,7 +18,7 @@ resource "cloudflare_dns_record" "apex" {
 resource "cloudflare_page_rule" "apex_to_www" {
   zone_id = cloudflare_zone.vanity.id
   target  = "bendrucker.me/*"
-  
+
   actions = {
     forwarding_url = {
       url         = "https://www.bendrucker.me/$1"

--- a/dns.tf
+++ b/dns.tf
@@ -17,11 +17,11 @@ resource "cloudflare_dns_record" "apex" {
 
 resource "cloudflare_page_rule" "apex_to_www" {
   zone_id = cloudflare_zone.vanity.id
-  target  = "bendrucker.me/*"
+  target  = "${cloudflare_zone.vanity.name}/*"
 
   actions = {
     forwarding_url = {
-      url         = "https://www.bendrucker.me/$1"
+      url         = "https://${cloudflare_dns_record.github.name}/$1"
       status_code = 301
     }
   }


### PR DESCRIPTION
Replace the external wwwizer service with Cloudflare native redirect functionality for bendrucker.me apex domain redirects.

## Changes
- Replace wwwizer A record (174.129.25.170) with proxied apex record using placeholder IP
- Add Cloudflare page rule for 301 redirect from bendrucker.me/* to https://www.bendrucker.me/$1
- Remove obsolete import/removed blocks for the old wwwizer record
- Document RFC 5737 TEST-NET-1 placeholder IP usage
