### PR TITLE
dns: switch www.bendrucker.me from GitHub Pages to Cloudflare Workers

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -14,11 +14,15 @@ resource "cloudflare_dns_record" "wwwizer" {
   ttl     = 1
 }
 
+data "cloudflare_workers_script" "bendrucker_me" {
+  name = "bendrucker-me"
+}
+
 resource "cloudflare_dns_record" "github" {
   zone_id = cloudflare_zone.vanity.id
   name    = "www.${cloudflare_zone.vanity.name}"
   type    = "CNAME"
-  content = "bendrucker.github.io"
+  content = data.cloudflare_workers_script.bendrucker_me.subdomain
   ttl     = 1
   proxied = true
 }

--- a/dns.tf
+++ b/dns.tf
@@ -15,7 +15,8 @@ resource "cloudflare_dns_record" "wwwizer" {
 }
 
 data "cloudflare_workers_script" "bendrucker_me" {
-  name = "bendrucker-me"
+  account_id  = var.cloudflare_account_id
+  script_name = "bendrucker-me"
 }
 
 resource "cloudflare_dns_record" "github" {


### PR DESCRIPTION
Replace hardcoded bendrucker.github.io CNAME with dynamic lookup of bendrucker-me Workers script subdomain using Terraform data source.

## Changes
- Add `cloudflare_workers_script` data source to look up `bendrucker-me` Workers script
- Update `www.bendrucker.me` DNS record to use dynamic subdomain reference instead of hardcoded GitHub Pages URL