### PR TITLE
fix: use custom ruleset kind to avoid zone conflict

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -19,7 +19,7 @@ resource "cloudflare_ruleset" "redirects" {
   zone_id     = cloudflare_zone.vanity.id
   name        = "redirects"
   description = "Single redirects ruleset"
-  kind        = "zone"
+  kind        = "custom"
   phase       = "http_request_dynamic_redirect"
 
   rules = [


### PR DESCRIPTION
Change from zone to custom kind to avoid conflict with existing zone-level ruleset for the http_request_dynamic_redirect phase.