### PR TITLE
dns: set compatibility_date on things-redirect worker

### DIFF
--- a/things.tf
+++ b/things.tf
@@ -1,8 +1,9 @@
 resource "cloudflare_workers_script" "things_redirect" {
-  account_id  = var.cloudflare_account_id
-  script_name = "things-redirect"
-  main_module = "worker.js"
-  content     = file("workers/things-redirect/worker.js")
+  account_id         = var.cloudflare_account_id
+  script_name        = "things-redirect"
+  main_module        = "worker.js"
+  content            = file("workers/things-redirect/worker.js")
+  compatibility_date = "2026-03-06"
 
   bindings = [{
     name = "HTML"


### PR DESCRIPTION
Sets `compatibility_date` on `cloudflare_workers_script.things_redirect` to force a re-upload of the worker, which is missing from the Cloudflare account and causing `https://things.bendrucker.me` to return `522`.

## Issue

`workers_list` on the account shows only `strava`, `bendrucker-me`, and `github`. The `things-redirect` worker is absent, so the route `things.bendrucker.me/*` has no handler, and `curl -sSI https://things.bendrucker.me/` returns `HTTP/2 522`.

The resource was introduced in #75 (`8b934f2`). Recent Terraform Cloud applies (#76, #77, #79, #84, #85) report `SUCCESS` on GitHub checks, yet the worker has not been restored. Forcing a visible diff via `compatibility_date` ensures the next apply re-uploads the script.

## Changes

- `things.tf`: add `compatibility_date = "2026-03-06"` to `cloudflare_workers_script.things_redirect`.

## Testing

After merge and apply:

- `workers_list` includes `things-redirect`.
- `curl -sSI https://things.bendrucker.me/` returns `200` with `content-type: text/html;charset=UTF-8`.
- `curl -s https://things.bendrucker.me/foo?bar=1` returns the redirect HTML body.
