### PR TITLE
ci: auto-merge clean Dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -41,8 +41,6 @@ jobs:
               await new Promise((resolve) => setTimeout(resolve, intervalMs))
             }
 
-            // The check is "success" even when the plan would change resources,
-            // so a clean plan also requires the "no changes" description.
             const clean = plan.state === 'success'
               && plan.description.trim() === 'Terraform plan has no changes'
             core.info(`Plan finished: state="${plan.state}" description="${plan.description}"`)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,83 @@
+name: Dependabot Auto-Merge
+on:
+  pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Wait for the Terraform Cloud plan
+        id: plan
+        uses: actions/github-script@v7
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+        with:
+          script: |
+            const checkName = 'Terraform Cloud/bendrucker/infrastructure'
+            const timeoutMs = 20 * 60 * 1000
+            const intervalMs = 30 * 1000
+            const deadline = Date.now() + timeoutMs
+            const sha = context.payload.pull_request.head.sha
+
+            let plan
+            while (true) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              })
+              plan = data.statuses.find((status) => status.context === checkName)
+              if (plan && plan.state !== 'pending') break
+              if (Date.now() > deadline) {
+                core.warning(`Timed out waiting for "${checkName}" to finish; leaving the PR for manual review.`)
+                core.setOutput('clean', 'false')
+                return
+              }
+              await new Promise((resolve) => setTimeout(resolve, intervalMs))
+            }
+
+            if (plan.state !== 'success') {
+              core.info(`Plan finished with state "${plan.state}"; not merging.`)
+              core.setOutput('clean', 'false')
+              return
+            }
+
+            // Prefer the structured run record from the Terraform Cloud API.
+            // Fall back to the status description text when no token is configured.
+            const runId = plan.target_url.match(/\/runs\/(run-[A-Za-z0-9]+)/)?.[1]
+            if (process.env.TF_API_TOKEN && runId) {
+              const response = await fetch(`https://app.terraform.io/api/v2/runs/${runId}`, {
+                headers: {
+                  Authorization: `Bearer ${process.env.TF_API_TOKEN}`,
+                  'Content-Type': 'application/vnd.api+json',
+                },
+              })
+              if (!response.ok) {
+                core.warning(`Terraform Cloud API returned ${response.status}; not merging.`)
+                core.setOutput('clean', 'false')
+                return
+              }
+              const { data: run } = await response.json()
+              const hasChanges = run.attributes['has-changes']
+              core.info(`Run ${runId} status="${run.attributes.status}" has-changes=${hasChanges}`)
+              core.setOutput('clean', hasChanges === false ? 'true' : 'false')
+              return
+            }
+
+            const clean = plan.description.trim() === 'Terraform plan has no changes'
+            core.info(`No TF_API_TOKEN configured; using status description: "${plan.description}"`)
+            core.setOutput('clean', clean ? 'true' : 'false')
+
+      - name: Enable auto-merge for a clean plan
+        if: steps.plan.outputs.clean == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --squash --auto

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,8 +16,6 @@ jobs:
       - name: Wait for the Terraform Cloud plan
         id: plan
         uses: actions/github-script@v7
-        env:
-          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
         with:
           script: |
             const checkName = 'Terraform Cloud/bendrucker/infrastructure'
@@ -43,36 +41,11 @@ jobs:
               await new Promise((resolve) => setTimeout(resolve, intervalMs))
             }
 
-            if (plan.state !== 'success') {
-              core.info(`Plan finished with state "${plan.state}"; not merging.`)
-              core.setOutput('clean', 'false')
-              return
-            }
-
-            // Prefer the structured run record from the Terraform Cloud API.
-            // Fall back to the status description text when no token is configured.
-            const runId = plan.target_url.match(/\/runs\/(run-[A-Za-z0-9]+)/)?.[1]
-            if (process.env.TF_API_TOKEN && runId) {
-              const response = await fetch(`https://app.terraform.io/api/v2/runs/${runId}`, {
-                headers: {
-                  Authorization: `Bearer ${process.env.TF_API_TOKEN}`,
-                  'Content-Type': 'application/vnd.api+json',
-                },
-              })
-              if (!response.ok) {
-                core.warning(`Terraform Cloud API returned ${response.status}; not merging.`)
-                core.setOutput('clean', 'false')
-                return
-              }
-              const { data: run } = await response.json()
-              const hasChanges = run.attributes['has-changes']
-              core.info(`Run ${runId} status="${run.attributes.status}" has-changes=${hasChanges}`)
-              core.setOutput('clean', hasChanges === false ? 'true' : 'false')
-              return
-            }
-
-            const clean = plan.description.trim() === 'Terraform plan has no changes'
-            core.info(`No TF_API_TOKEN configured; using status description: "${plan.description}"`)
+            // The check is "success" even when the plan would change resources,
+            // so a clean plan also requires the "no changes" description.
+            const clean = plan.state === 'success'
+              && plan.description.trim() === 'Terraform plan has no changes'
+            core.info(`Plan finished: state="${plan.state}" description="${plan.description}"`)
             core.setOutput('clean', clean ? 'true' : 'false')
 
       - name: Enable auto-merge for a clean plan


### PR DESCRIPTION
Dependabot opens a provider bump every week, and each one is safe to merge only when Terraform Cloud plans no infrastructure changes. This adds a workflow that waits for that plan and merges the PR automatically when it comes back clean.

## How it works

The workflow triggers on `pull_request_target` and runs only for `dependabot[bot]`. It polls the `Terraform Cloud/bendrucker/infrastructure` commit status on the PR head until that check reaches a terminal state. If the check never finishes within 20 minutes, it logs a warning and leaves the PR untouched for manual review.

Once the plan finishes, the workflow merges only when it is clean: state `success` and a description of `Terraform plan has no changes`. The state alone is not enough. Terraform Cloud reports `success` even when the plan would add, change, or destroy resources, so the description is what distinguishes a no-op bump from one that alters infrastructure.

The description is read from the commit status object, the same structured payload that carries the state and the run URL. It is the only "no changes" signal available without authenticating to the Terraform Cloud API, and it avoids managing an API token as a repository secret.

When the plan is clean, the workflow enables native auto-merge with squash. GitHub completes the merge once all required checks (`Terraform Cloud/bendrucker/infrastructure`, `tflint`, `fmt`) pass.

## Why `pull_request_target`

A workflow triggered by Dependabot on a plain `pull_request` event gets a read-only `GITHUB_TOKEN`, so it cannot merge. `pull_request_target` runs in the base-repo context with a writable token. The workflow never checks out or executes PR code. It only calls the GitHub API and merges, so the usual `pull_request_target` injection risk does not apply.
