### PR TITLE
Serve activity-hub at hub.bendrucker.me behind Access

### DIFF
--- a/activity-hub.tf
+++ b/activity-hub.tf
@@ -1,0 +1,96 @@
+resource "cloudflare_dns_record" "hub" {
+  zone_id = cloudflare_zone.vanity.id
+  name    = "hub.${cloudflare_zone.vanity.name}"
+  type    = "A"
+  content = "192.0.2.1"
+  ttl     = 1
+  proxied = true
+}
+
+# The script itself is deployed by wrangler from the activity-hub repo. Only
+# the hostname and the route belong here.
+resource "cloudflare_workers_route" "hub" {
+  zone_id = cloudflare_zone.vanity.id
+  pattern = "${cloudflare_dns_record.hub.name}/*"
+  script  = "activity-hub-ingest"
+}
+
+resource "cloudflare_zero_trust_access_policy" "hub_owner" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub owner"
+  decision   = "allow"
+
+  include = [{
+    email = {
+      email = "bvdrucker@gmail.com"
+    }
+  }]
+}
+
+resource "cloudflare_zero_trust_access_service_token" "hub" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub automation"
+}
+
+# Service tokens carry no identity, so they need a policy that asks for none.
+resource "cloudflare_zero_trust_access_policy" "hub_automation" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub automation"
+  decision   = "non_identity"
+
+  include = [{
+    service_token = {
+      token_id = cloudflare_zero_trust_access_service_token.hub.id
+    }
+  }]
+}
+
+# Access matches on hostname and path prefix, so /webhooks stays reachable by
+# being covered by no application at all. Strava and Wahoo post to it server to
+# server and would fail any challenge.
+resource "cloudflare_zero_trust_access_application" "hub_admin" {
+  account_id       = var.cloudflare_account_id
+  name             = "activity-hub admin"
+  domain           = "${cloudflare_dns_record.hub.name}/admin"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.hub_owner.id
+      precedence = 1
+    },
+    {
+      id         = cloudflare_zero_trust_access_policy.hub_automation.id
+      precedence = 2
+    },
+  ]
+}
+
+# The OAuth callbacks land here as browser navigations, so the owner policy
+# alone covers them. Nothing automated hits /auth.
+resource "cloudflare_zero_trust_access_application" "hub_auth" {
+  account_id       = var.cloudflare_account_id
+  name             = "activity-hub auth"
+  domain           = "${cloudflare_dns_record.hub.name}/auth"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.hub_owner.id
+      precedence = 1
+    },
+  ]
+}
+
+output "activity_hub_access_client_id" {
+  description = "CF-Access-Client-Id header value for activity-hub scripts"
+  value       = cloudflare_zero_trust_access_service_token.hub.client_id
+}
+
+output "activity_hub_access_client_secret" {
+  description = "CF-Access-Client-Secret header value for activity-hub scripts"
+  value       = cloudflare_zero_trust_access_service_token.hub.client_secret
+  sensitive   = true
+}


### PR DESCRIPTION
Puts activity-hub's admin surface on `hub.bendrucker.me` behind Access. It has been served from `workers.dev` with a bearer token as the only thing in front of it.

DNS and routing follow the `things.bendrucker.me` pattern: a proxied placeholder record plus a `cloudflare_workers_route` at `activity-hub-ingest`. Terraform owns the hostname, wrangler keeps deploying the script from the activity-hub repo. The alternative was wrangler's `custom_domain`, which would have written a DNS record into a zone this repo otherwise owns.

Access covers `/admin` and `/auth` by path prefix. `/webhooks` is deliberately covered by no application, because Strava and Wahoo post to it server to server and would fail any challenge. The owner policy is a one-time PIN to my email, which keeps the whole thing in Terraform with no OAuth app to register out of band. The service token gets its own `non_identity` policy, since a token presents no identity to check against.

## Applying this changes nothing yet

`workers.dev` keeps serving throughout, so the old hostname stays reachable and live webhooks keep flowing. That is deliberate: the providers still point at the workers.dev callback, and cutting it off before they move would drop events.

After this applies, the remaining sequence is:

1. Register the `hub.bendrucker.me` redirect URIs in the Strava and Wahoo app settings
2. Re-authorize both through the new host. `redirectUri()` derives from `url.origin`, so no code change
3. Recreate the Strava subscription against the new callback, and update the Wahoo webhook URL
4. Set `workers_dev: false` in activity-hub and deploy. This is the step that actually secures anything, since every policy here is bypassable through the workers.dev hostname while it serves

## Worth knowing

The service token secret is only available at creation, so it is an output. `activity_hub_access_client_secret` is sensitive; read it once and put it wherever the local scripts read their config.

There is no `cloudflare_zero_trust_organization` resource here. Zero Trust is already in use on this account, so the applications have an organization to attach to and the team domain stays owned wherever it was set up. If the apply disagrees, that is the resource it wants.

Checked with `terraform validate` against the real provider schema and with `tflint`. Local validation needed a scratch root, because the credentials helper this machine uses for `app.terraform.io` is built for the wrong architecture and cannot return a token.
