### PR TITLE
Mint scoped R2 tokens for activity-hub

### DIFF
--- a/activity-hub.tf
+++ b/activity-hub.tf
@@ -84,6 +84,68 @@ resource "cloudflare_zero_trust_access_application" "hub_auth" {
   ]
 }
 
+# Cloudflare bindings do not cross into a container, so the activity-hub decode
+# container reaches R2 over the S3 API instead. An R2 token carries one
+# permission level across every bucket it covers, which is why reading raw and
+# writing lake are two tokens rather than one.
+
+data "cloudflare_account_api_token_permission_groups_list" "account" {
+  account_id = var.cloudflare_account_id
+}
+
+locals {
+  # one() fails the apply on an ambiguous match instead of picking a group at
+  # random, which would mint a token with the wrong permission.
+  r2_bucket_read = one([
+    for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+    group.id if group.name == "Workers R2 Storage Bucket Item Read"
+  ])
+
+  r2_bucket_write = one([
+    for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+    group.id if group.name == "Workers R2 Storage Bucket Item Write"
+  ])
+
+  # Buckets created outside a jurisdiction take `default` in the resource key.
+  r2_bucket_resource_prefix = "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_"
+}
+
+resource "cloudflare_account_token" "hub_r2_raw" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub raw read"
+  expires_on = "2027-08-12T00:00:00Z"
+
+  policies = [{
+    effect = "allow"
+
+    permission_groups = [{
+      id = local.r2_bucket_read
+    }]
+
+    resources = jsonencode({
+      "${local.r2_bucket_resource_prefix}activity-hub-raw" = "*"
+    })
+  }]
+}
+
+resource "cloudflare_account_token" "hub_r2_lake" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub lake write"
+  expires_on = "2027-08-12T00:00:00Z"
+
+  policies = [{
+    effect = "allow"
+
+    permission_groups = [{
+      id = local.r2_bucket_write
+    }]
+
+    resources = jsonencode({
+      "${local.r2_bucket_resource_prefix}activity-hub-lake" = "*"
+    })
+  }]
+}
+
 output "activity_hub_access_client_id" {
   description = "CF-Access-Client-Id header value for activity-hub scripts"
   value       = cloudflare_zero_trust_access_service_token.hub.client_id
@@ -92,5 +154,30 @@ output "activity_hub_access_client_id" {
 output "activity_hub_access_client_secret" {
   description = "CF-Access-Client-Secret header value for activity-hub scripts"
   value       = cloudflare_zero_trust_access_service_token.hub.client_secret
+  sensitive   = true
+}
+
+# S3 reads the token id as the access key id and the SHA-256 of the token value
+# as the secret access key. The raw token value is not the secret.
+
+output "activity_hub_r2_raw_access_key_id" {
+  description = "S3 access key id for reading activity-hub-raw"
+  value       = cloudflare_account_token.hub_r2_raw.id
+}
+
+output "activity_hub_r2_raw_secret_access_key" {
+  description = "S3 secret access key for reading activity-hub-raw"
+  value       = sha256(cloudflare_account_token.hub_r2_raw.value)
+  sensitive   = true
+}
+
+output "activity_hub_r2_lake_access_key_id" {
+  description = "S3 access key id for writing activity-hub-lake"
+  value       = cloudflare_account_token.hub_r2_lake.id
+}
+
+output "activity_hub_r2_lake_secret_access_key" {
+  description = "S3 secret access key for writing activity-hub-lake"
+  value       = sha256(cloudflare_account_token.hub_r2_lake.value)
   sensitive   = true
 }


### PR DESCRIPTION
Adds the two scoped R2 API tokens the `activity-hub` decode container needs. It runs as a Cloudflare Container, and bindings do not cross that boundary. So it reaches R2 over the S3 API with credentials instead of a `R2Bucket` binding.

Two tokens, because an R2 token applies a single permission level across every bucket it covers. Splitting them keeps the container's read path off the lake and its write path off the raw archive, the one bucket nothing should ever be able to overwrite. `expires_on` is a year out. Rotation becomes a scheduled apply rather than a thing to remember.

The permission group ids come from `cloudflare_account_api_token_permission_groups_list` instead of being pasted in. Cloudflare publishes the id for `Workers R2 Storage Bucket Item Read` and not the one for `Write`, and an opaque hex string in the diff is unreviewable either way. `one()` wraps each lookup, so an ambiguous match fails the apply instead of quietly minting a token with the wrong permission.

S3 does not take the token value as the secret access key. It takes the token id as the access key id and the SHA-256 of the token value as the secret. That is why the outputs hash rather than handing back `.value`. Get it wrong and the token authenticates nowhere, with no error explaining why.

## Applying

The workspace's `CLOUDFLARE_API_TOKEN` needed `Account API Tokens Read` for the data source and `Account API Tokens Write` to create either token. It had neither, and the first plan 403'd with code 9109. Both are granted now. The apply adds the two tokens and touches nothing else.

After it applies, these become worker secrets in `activity-hub` via `wrangler secret put`, alongside `R2_ACCOUNT_ID`:

```sh
terraform output -raw activity_hub_r2_raw_access_key_id
terraform output -raw activity_hub_r2_raw_secret_access_key
terraform output -raw activity_hub_r2_lake_access_key_id
terraform output -raw activity_hub_r2_lake_secret_access_key
```

Set them before the next `activity-hub` deploy. The daily reconcile cron enqueues up to 1,000 activities, and a container with no credentials fails every one of them through its retries and parks them as `failed`.
