### PR TITLE
Mint an automation token for activity-hub

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -41,3 +41,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f6b6c7bb2dbf04ee085e5c22f7a65b3ccaebf368ed95584dc0dfee8a22771056",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/activity-hub.tf
+++ b/activity-hub.tf
@@ -108,6 +108,28 @@ locals {
 
   # Buckets created outside a jurisdiction take `default` in the resource key.
   r2_bucket_resource_prefix = "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_"
+
+  # Wrangler touches a different Cloudflare API for each binding activity-hub
+  # declares, so a token that covers deploys but not D1 fails halfway through a
+  # migration. The list mirrors the bindings in wrangler.jsonc.
+  automation_permission_group_names = [
+    "Workers Scripts Write",
+    "Workers KV Storage Write",
+    "Workers R2 Storage Write",
+    "Workers Tail Read",
+    "D1 Write",
+    "Queues Write",
+    "Containers Write",
+  ]
+
+  automation_permission_groups = [
+    for name in local.automation_permission_group_names : {
+      id = one([
+        for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+        group.id if group.name == name
+      ])
+    }
+  ]
 }
 
 resource "cloudflare_account_token" "hub_r2_raw" {
@@ -179,5 +201,64 @@ output "activity_hub_r2_lake_access_key_id" {
 output "activity_hub_r2_lake_secret_access_key" {
   description = "S3 secret access key for writing activity-hub-lake"
   value       = sha256(cloudflare_account_token.hub_r2_lake.value)
+  sensitive   = true
+}
+
+# Wrangler's own OAuth login expires within a day and cannot be refreshed
+# non-interactively, which stalls any unattended work against the worker. This
+# token replaces that login, and rotating it is an apply rather than a browser
+# round trip.
+
+resource "cloudflare_account_token" "hub_automation" {
+  account_id = var.cloudflare_account_id
+  name       = "activity-hub automation"
+  expires_on = "2027-08-12T00:00:00Z"
+
+  policies = [{
+    effect            = "allow"
+    permission_groups = local.automation_permission_groups
+
+    resources = jsonencode({
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    })
+  }]
+
+  lifecycle {
+    precondition {
+      # A name that stops matching yields a null id, which Cloudflare rejects
+      # with an error naming neither the token nor the group.
+      condition = alltrue([
+        for group in local.automation_permission_groups : group.id != null
+      ])
+      error_message = join(" ", [
+        "One of automation_permission_group_names no longer matches a Cloudflare permission group.",
+        "Available account groups:",
+        join(", ", sort([
+          for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+          group.name
+        ])),
+      ])
+    }
+  }
+}
+
+# The admin routes authenticate a bearer token behind Access. Generating it here
+# means an unattended session can read it back from state instead of asking for
+# a value only the worker knows.
+
+resource "random_password" "hub_admin" {
+  length  = 48
+  special = false
+}
+
+output "activity_hub_admin_token" {
+  description = "Bearer token for the activity-hub /admin routes"
+  value       = random_password.hub_admin.result
+  sensitive   = true
+}
+
+output "activity_hub_cloudflare_api_token" {
+  description = "CLOUDFLARE_API_TOKEN for wrangler against activity-hub"
+  value       = cloudflare_account_token.hub_automation.value
   sensitive   = true
 }

--- a/activity-hub.tf
+++ b/activity-hub.tf
@@ -119,7 +119,9 @@ locals {
     "Workers Tail Read",
     "D1 Write",
     "Queues Write",
-    "Containers Write",
+    "Workers Containers Write",
+    "Workers R2 Data Catalog Write",
+    "Account Settings Read",
   ]
 
   automation_permission_groups = [

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,11 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   required_version = ">= 0.13"


### PR DESCRIPTION
Adds an `activity-hub automation` account token and a generated admin bearer token, both exposed as workspace outputs.

Wrangler authenticates through an OAuth login that expires within a day and cannot refresh in a non-interactive environment. Every unattended session working on `activity-hub` eventually hits that wall and has to stop and wait for someone to run `wrangler login` in a terminal. It happened twice while landing the transform pipeline. Setting `CLOUDFLARE_API_TOKEN` from this output removes the interactive step, and rotation becomes a scheduled apply against `expires_on` rather than a browser round trip.

`ADMIN_TOKEN` has the same shape of problem from the other direction. It is a write-only worker secret, so nothing that didn't set it can read it back, and the local copy had already drifted out of sync with what the worker enforces. Generating it here means a session can read the current value back from state instead of guessing whether its copy still matches.

The token is account-scoped and carries write on Workers Scripts, KV, R2, D1, Queues, and Containers, plus tail read. That is the set `wrangler` needs to deploy, apply migrations, manage queues, put secrets, and read logs, which mirrors what the GitHub Actions token already holds. A precondition fails the plan if any permission group name stops matching, and prints the available account groups, because a name that silently resolves to null mints a token with the wrong permission.

## Applying

The apply creates two tokens and touches nothing else. Afterward the five consuming values come from `terraform output`.
