### PR TITLE
Add a Cloudflare API token for bendrucker.me CI

### DIFF
--- a/bendrucker-me.tf
+++ b/bendrucker-me.tf
@@ -1,0 +1,69 @@
+# CI in the bendrucker.me repo deploys four workers and applies the D1
+# migrations with a single token. The token in the repo secret predates the
+# database, so `d1 migrations apply` answers 7403 and the deploy job it gates
+# has never run. Minting the token here means the permission list is reviewable
+# and a rotation is an apply rather than a click.
+
+locals {
+  # Mirrors the bindings across bendrucker.me's four wrangler configs: the
+  # worker scripts themselves, the activity database the site and the github
+  # worker share, the session and strava namespaces, and the activity-hub raw
+  # bucket the photo route reads.
+  bendrucker_me_permission_group_names = [
+    "Workers Scripts Write",
+    "D1 Write",
+    "Workers KV Storage Write",
+    "Workers R2 Storage Write",
+    "Account Settings Read",
+  ]
+
+  bendrucker_me_permission_groups = [
+    for name in local.bendrucker_me_permission_group_names : {
+      id = one([
+        for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+        group.id if group.name == name
+      ])
+    }
+  ]
+}
+
+resource "cloudflare_account_token" "bendrucker_me_ci" {
+  account_id = var.cloudflare_account_id
+  name       = "bendrucker.me CI"
+  # Shared with the activity-hub tokens so one rotation covers every token this
+  # workspace issues.
+  expires_on = "2027-08-12T00:00:00Z"
+
+  policies = [{
+    effect            = "allow"
+    permission_groups = local.bendrucker_me_permission_groups
+
+    resources = jsonencode({
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    })
+  }]
+
+  lifecycle {
+    precondition {
+      # A name that stops matching yields a null id, which Cloudflare rejects
+      # with an error naming neither the token nor the group.
+      condition = alltrue([
+        for group in local.bendrucker_me_permission_groups : group.id != null
+      ])
+      error_message = join(" ", [
+        "One of bendrucker_me_permission_group_names no longer matches a Cloudflare permission group.",
+        "Available account groups:",
+        join(", ", sort([
+          for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+          group.name
+        ])),
+      ])
+    }
+  }
+}
+
+output "bendrucker_me_ci_cloudflare_api_token" {
+  description = "CLOUDFLARE_API_TOKEN secret for the bendrucker/bendrucker.me repo"
+  value       = cloudflare_account_token.bendrucker_me_ci.value
+  sensitive   = true
+}


### PR DESCRIPTION
Mints `bendrucker.me CI` as a `cloudflare_account_token` and exposes its value as a sensitive output.

## Why

The `CLOUDFLARE_API_TOKEN` secret on `bendrucker/bendrucker.me` was issued before that repo had a D1 database. It carries Workers permissions and no D1 scope, so `wrangler d1 migrations apply bendrucker-activity --remote` answers:

```
The given account is not valid or is not authorized to access this service [code: 7403]
```

The migrate job landed Aug 6 in 8b9440f (#586) and has failed on every run since. It has never once succeeded. The deploy jobs declare `needs: migrate`, so nothing has shipped to the site since Aug 3.

## Permissions

The list mirrors the bindings across bendrucker.me's four wrangler configs (www, github, strava, stories):

| Group | Covers |
| --- | --- |
| Workers Scripts Write | deploying the four scripts |
| D1 Write | the `bendrucker-activity` migrations |
| Workers KV Storage Write | the session and strava namespaces |
| Workers R2 Storage Write | the `activity-hub-raw` bucket the photo route reads |
| Account Settings Read | wrangler's account lookup |

An `alltrue` lifecycle precondition fails the apply with a readable message when a permission-group name stops matching, listing the account's available groups. Without it a renamed group yields a null id and Cloudflare rejects the token with an error naming neither.

## Duplicated Lookup

`activity-hub.tf` already builds a permission-group list the same way. This adds a second copy instead of extracting a shared module. The activity-hub token works today, and it is the only working half of the two, so folding both onto one lookup would put it at risk alongside the thing being fixed. The cost is a duplicated `for` comprehension across two files.

## After Apply

1. Read the token: `terraform output -raw bendrucker_me_ci_cloudflare_api_token`
2. Set it as `CLOUDFLARE_API_TOKEN` on `bendrucker/bendrucker.me`
3. Re-run the failed Deploy run
