### PR TITLE
Add zone route scope to bendrucker.me CI token

### DIFF
--- a/bendrucker-me.tf
+++ b/bendrucker-me.tf
@@ -17,6 +17,13 @@ locals {
     "Account Settings Read",
   ]
 
+  # Worker routes are zone-scoped, so they cannot ride along in the account
+  # policy above and need a second policy naming the zone.
+  bendrucker_me_routes_write = one([
+    for group in data.cloudflare_account_api_token_permission_groups_list.account.result :
+    group.id if group.name == "Workers Routes Write"
+  ])
+
   bendrucker_me_permission_groups = [
     for name in local.bendrucker_me_permission_group_names : {
       id = one([
@@ -34,24 +41,40 @@ resource "cloudflare_account_token" "bendrucker_me_ci" {
   # workspace issues.
   expires_on = "2027-08-12T00:00:00Z"
 
-  policies = [{
-    effect            = "allow"
-    permission_groups = local.bendrucker_me_permission_groups
+  policies = [
+    {
+      effect            = "allow"
+      permission_groups = local.bendrucker_me_permission_groups
 
-    resources = jsonencode({
-      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
-    })
-  }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+      })
+    },
+    # The www worker declares a custom_domain route, so wrangler updates
+    # /zones/{zone}/workers/routes on every deploy.
+    {
+      effect = "allow"
+
+      permission_groups = [{
+        id = local.bendrucker_me_routes_write
+      }]
+
+      resources = jsonencode({
+        "com.cloudflare.api.account.zone.${cloudflare_zone.vanity.id}" = "*"
+      })
+    },
+  ]
 
   lifecycle {
     precondition {
       # A name that stops matching yields a null id, which Cloudflare rejects
       # with an error naming neither the token nor the group.
-      condition = alltrue([
-        for group in local.bendrucker_me_permission_groups : group.id != null
-      ])
+      condition = alltrue(concat(
+        [for group in local.bendrucker_me_permission_groups : group.id != null],
+        [local.bendrucker_me_routes_write != null],
+      ))
       error_message = join(" ", [
-        "One of bendrucker_me_permission_group_names no longer matches a Cloudflare permission group.",
+        "A bendrucker.me CI permission group name no longer matches a Cloudflare permission group.",
         "Available account groups:",
         join(", ", sort([
           for group in data.cloudflare_account_api_token_permission_groups_list.account.result :


### PR DESCRIPTION
Adds a zone-scoped policy carrying `Workers Routes Write` to the `bendrucker.me CI` token.

## Why

#121 minted this token with a single account-scoped policy. `Workers Routes Write` is zone-scoped (`com.cloudflare.api.account.zone`), so the token could not touch routes on any zone. The token it replaced could.

The www deploy uploaded the script and then failed on the route update:

```
A request to the Cloudflare API (/zones/c783f775892feb7781197c65222d9612/workers/routes) failed.
  Authentication error [code: 10000]
```

Only the root `wrangler.toml` in bendrucker.me declares `[[routes]]`, a `custom_domain` for `www.bendrucker.me`. The github, strava and stories workers declare none, which is why those three deployed cleanly on the same run.

## Scope

The new policy names the `bendrucker.me` zone through `cloudflare_zone.vanity` rather than granting routes across all zones. The account-scoped policy is unchanged.

The precondition now covers the routes group too, so a rename of any group in either policy still fails the apply with the available group names rather than an opaque Cloudflare rejection.

## Verification

`terraform fmt` passes. `terraform validate` did not run locally, so this has HCL-syntax checking but not provider-schema checking. The TFC plan on this PR covers that.

After apply, re-run the Deploy workflow on bendrucker/bendrucker.me. The `migrations` job and three of the four worker deploys already pass as of run 32086100159 attempt 2. `www` is the remaining failure.
