### PR TITLE
Point the tsidp grant at tailgate's real upstream

### DIFF
--- a/tailscale.tf
+++ b/tailscale.tf
@@ -1,14 +1,31 @@
 # tailscale_acl manages the tailnet policy file in its entirety, not a fragment of
 # it, so this file is the sole source of truth for every rule in the tailnet.
-# tailscale/policy.hujson is a verbatim capture of the live policy, taken so that
-# the first plan after import is a no-op.
 #
 # overwrite_existing_content is deliberately unset. It defaults to false, which
 # makes the provider send a "ts-default" ETag on create and refuse to clobber a
 # policy that has been edited away from the default. Setting it to true to clear
 # an error would trade that guard for a silent tailnet-wide overwrite.
+locals {
+  tailnet_policy = file("tailscale/policy.hujson")
+}
+
 resource "tailscale_acl" "this" {
-  acl = file("tailscale/policy.hujson")
+  acl = local.tailnet_policy
+
+  # The policy's own "tests" block covers reachability, which is all Tailscale
+  # can validate server-side. Neither node attributes nor app capability grants
+  # are expressible as tests, so the two invariants that decide whether tailgate
+  # works at all are checked here instead, at plan time.
+  lifecycle {
+    precondition {
+      condition     = strcontains(local.tailnet_policy, "https://tailgate.tailaa2f5e.ts.net/mcp/things")
+      error_message = "The tsidp grant no longer carries tailgate's canonical resource URI. tsidp compares the RFC 8707 resource parameter against this string with ==, so any edit to it denies every request at the audience check and logs nothing above debug. Regenerate the grant with `tailgate grant` rather than editing the string."
+    }
+    precondition {
+      condition     = strcontains(local.tailnet_policy, "\"funnel\"")
+      error_message = "No node attribute grants funnel. tailgate is served over Tailscale Funnel and stops accepting public traffic without it."
+    }
+  }
 }
 
 import {

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -94,9 +94,7 @@
 							"*",
 						],
 						"resources": [
-							"https://tailgate.tailaa2f5e.ts.net/mcp/fake",
-							"https://tailgate.tailaa2f5e.ts.net/mcp/files",
-							"https://tailgate.tailaa2f5e.ts.net/mcp/denied",
+							"https://tailgate.tailaa2f5e.ts.net/mcp/things",
 						],
 						"allow_admin_ui": true,
 						"allow_dcr":      true,
@@ -106,12 +104,33 @@
 		},
 	],
 
-	// Test access rules every time they're saved.
-	// "tests": [
-	//   {
-	//       "src": "alice@example.com",
-	//       "accept": ["tag:example"],
-	//       "deny": ["100.101.102.103:443"],
-	//   },
-	// ],
+	// Named so the tests below can refer to them. Tests match destinations as
+	// ip:port, and a bare MagicDNS name is not a valid ACL destination.
+	"hosts": {
+		"tailgate": "100.100.143.65",
+		"idp":      "100.95.42.112",
+	},
+
+	// Tailscale validates these server-side on every save, so a policy that
+	// breaks one of these paths fails the apply instead of reaching the tailnet.
+	//
+	// Both assertions are trivially true while the grant above is "src": ["*"],
+	// "dst": ["*"], "ip": ["*"]. They exist for the edit that narrows it, which
+	// the default policy's own comment invites.
+	"tests": [
+		{
+			// tailgate introspects every bearer token against tsidp before
+			// proxying. Cut this path and every request fails auth with nothing
+			// in tailgate's logs naming the tailnet as the cause.
+			"src":    "tailgate",
+			"accept": ["idp:443"],
+		},
+		{
+			// Reaching tailgate from inside the tailnet. Funnel traffic arrives
+			// from the public internet and never consults this, so losing it
+			// breaks tailnet clients only.
+			"src":    "bvdrucker@gmail.com",
+			"accept": ["tailgate:443"],
+		},
+	],
 }


### PR DESCRIPTION
Restores remote access to Things, which is broken on the live tailnet right now.

The tsidp grant authorized `/mcp/fake`, `/mcp/files`, and `/mcp/denied`. None of the three is a configured upstream, and `files` is a fixture name in tailgate's own tests (`upstreams_test.go`, `internal/grant/grant_test.go`), so that block was pasted from a test run rather than generated from the production config. tailgate serves exactly one upstream, `things`. Nothing in the tailnet authorized its audience, and the policy's other tsidp grant covers `studio.tailaa2f5e.ts.net/mcp`, a different node.

A session working the MCP client bring-up traced the same failure from the other end and reached the same resource string. `claude mcp login things` returns `invalid resource` from tsidp's `validateResourcesForUser`, which matches with `allowedResource == resource` and has no canonicalization step. The 400 is written at `slog.Debug` while tsidp runs at `info`, so the failure logs nothing that names a cause.

The replacement resource string is `tailgate grant` output, extracted from the generator's JSON rather than typed. `allow_admin_ui` and `allow_dcr` are unchanged from what is live.

## Preconditions over tests

Tailscale's `tests` block covers `src`, `srcPostureAttrs`, `proto`, `accept`, and `deny`. It cannot assert a `nodeAttrs` entry, and it cannot assert an app capability grant, which happens to be both of the invariants that decide whether tailgate works. The two `lifecycle.precondition` blocks in `tailscale.tf` cover them with `strcontains` at plan time instead. Crude, and a byte comparison is exactly the guarantee that resource string needs.

## Tests

Two, both about paths whose loss would be silent. tailgate reaching tsidp on 443, because every request introspects a token before proxying. Tailnet clients reaching tailgate on 443, which Funnel traffic bypasses and so would not reveal.

Both pass trivially while the network grant is still `"src": ["*"], "dst": ["*"], "ip": ["*"]`. They start mattering at the edit that narrows it, which the default policy's own comment invites. The `hosts` block exists because test destinations match as `ip:port` and a bare MagicDNS name is not a valid ACL destination.

No `sshTests`. The SSH rule is check-mode access to your own devices, and breaking it costs a prompt rather than an outage.

## Open

Whether `allow_dcr` should stay. It is unchanged here on your instruction, and the bring-up session argues for dropping it: tsidp accumulates the flag across all rules, so DCR is on tailnet-wide, and tailgate's `CLAUDE.md` calls DCR deprecated as of 2026-07-28 with pre-registered confidential clients as the preferred path. `/register` is tailnet-only, so nothing is exposed publicly. Dropping it is a one-line follow-up if you want it.

Also unaddressed: the first grant's `app` block still authorizes `studio.tailaa2f5e.ts.net/mcp`, the retired mcp-gate resource. Its network rule is unrelated and should stay.
