### PR TITLE
Scope the tsidp allow flags to a single identity

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -74,7 +74,6 @@
 				"tailscale.com/cap/tsidp": [{
 					"users":     ["bvdrucker@gmail.com"],
 					"resources": ["https://studio.tailaa2f5e.ts.net/mcp"],
-					"allow_dcr": true,
 				}],
 			},
 		},
@@ -96,10 +95,26 @@
 						"resources": [
 							"https://tailgate.tailaa2f5e.ts.net/mcp/things",
 						],
-						"allow_admin_ui": true,
-						"allow_dcr":      true,
 					},
 				],
+			},
+		},
+		// tsidp accumulates allow_admin_ui and allow_dcr across every rule in the
+		// caller's CapMap and never reads a rule's "users", so the grant's "src" is
+		// the only thing that scopes them. Carrying them on the grants above handed
+		// both to every node in the tailnet, tagged nodes included.
+		//
+		// This rule sets no "users" or "resources" on purpose. Neither would do
+		// anything here, and a rule that matches no resource is skipped rather than
+		// rejected, so it cannot affect the audience check above.
+		{
+			"src": ["bvdrucker@gmail.com"],
+			"dst": ["*"],
+			"app": {
+				"tailscale.com/cap/tsidp": [{
+					"allow_admin_ui": true,
+					"allow_dcr":      true,
+				}],
 			},
 		},
 	],


### PR DESCRIPTION
`allow_dcr` and `allow_admin_ui` were reachable by far more of the tailnet than intended, because the field that looks like it scopes them does not.

tsidp's `addGrantAccessContext` walks every rule in the caller's CapMap and sets `allowAdminUI` / `allowDCR` from the booleans alone. It never reads `rule.Users`. A rule's `users` field is consulted only in `validateResourcesForUser`, and only to filter resources. So the grant's `src` is the only thing that decides who holds these flags.

That made the live policy wider than it looked. `allow_dcr` sat on the grant with `"src": ["*"]`, which is every node in the tailnet, tagged nodes included, despite that rule's `users` naming a single account. `allow_admin_ui` sat on the `autogroup:member` grant, so any member reached the tsidp admin UI.

Both now ride a dedicated grant scoped by `src` to one identity.

## Why this is worth tightening

A self-registered confidential client's credentials introspect any outstanding token, from the public internet over Funnel: `identifyClient` matches client credentials before any network gate, and `serveIntrospect` looks a token up by string with no scoping to the calling client. DCR turns tailnet presence into a durable internet-reachable capability, which is why bounding who can obtain one matters even on a single-person tailnet.

## The new rule carries no users or resources

Deliberate. Neither field would do anything for a flags-only rule. `validateResourcesForUser` iterates rules and computes `userMatches` over `rule.Users`; a nil slice yields no match, so the rule is skipped rather than rejected. The tailgate audience check that PR #124 restored matches on its own rule and is unaffected.

## Side effect worth having

Stripping the flags from the generated grant leaves it byte-identical to bare `tailgate grant` output. Regenerating it after an upstream change is now a no-op rather than something that silently drops flags someone hand-added.

Verified against `tailscale/tsidp` v0.0.14, the version running on the Studio.
